### PR TITLE
ensure handlers go thorugh final error/success handlers; linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+  "rules": {
+    "quotes": [ 2 ],
+    "no-redeclare": 2,
+    "no-shadow": 2,
+    "semi": [2, "always"],
+    "no-else-return": 2,
+    "default-case": 2,
+    "comma-dangle": [2, "always-multiline"],
+    "no-dupe-keys": 2,
+    "no-duplicate-case": 2,
+    "no-func-assign": 2,
+    "no-undef": 2,
+  },
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const urlgrey = require("urlgrey");
+const pTry = require("p-try");
 
 const methods = require("methods").map(m => m.toUpperCase());
 
@@ -28,6 +29,12 @@ class Detour {
 
     if (route == null) return next();
 
+    const attempt = (fn, ...args) => {
+      return pTry(() => fn(...args))
+        .then(result => this._handleOk(ctx, result))
+        .catch(err => this._handleErr(ctx, err));
+    };
+
     ctx.route = route;
     ctx.resource = route.resource;
     ctx.params = route.params(path);
@@ -36,16 +43,16 @@ class Detour {
 
     if (ctx.resource[method] == null) {
       switch (method) {
-        case "HEAD": return this._handlers.HEAD(ctx, next, this);
-        case "OPTIONS": return this._handlers.OPTIONS(ctx);
-        default: return this._handlers.methodNotAllowed(ctx);
+        case "HEAD": return attempt(this._handlers.HEAD, ctx, next, this);
+        case "OPTIONS": return attempt(this._handlers.OPTIONS, ctx);
+        default: return attempt(this._handlers.methodNotAllowed, ctx);
       }
     }
 
-    return pipeCtx(ctx, this._middleware)
-      .then(() => ctx.resource[method](ctx))
-      .then(result => this._handleOk(ctx, result))
-      .catch(err => this._handleErr(ctx, err))
+    return attempt(() => {
+      return pipeCtx(ctx, this._middleware)
+        .then(() => ctx.resource[method](ctx));
+    });
   }
 
   // to special-handle rejections
@@ -71,8 +78,9 @@ class Detour {
   }
 
   handle (type, handler) {
+
     if (!defaultHandlers.hasOwnProperty(type)) {
-      throw new Error(`\`type\` argument must be one of "OPTIONS", "HEAD", "methodNotAllowed", found: ${type}`)
+      throw new Error(`\`type\` argument must be one of 'OPTIONS', 'HEAD', 'methodNotAllowed', found: ${type}`);
     }
 
     if (typeof handler !== "function") {
@@ -101,7 +109,7 @@ class Detour {
 const defaultHandlers = {
   methodNotAllowed (ctx) {
     const header = getMethods(ctx.resource).join(",");
-    ctx.set("Allow", header)
+    ctx.set("Allow", header);
     ctx.status = 405;
     ctx.body = "Method Not Allowed";
   },
@@ -123,7 +131,7 @@ const defaultHandlers = {
     ctx.req.method = "GET";
     return router._dispatch(ctx, next);
   },
-}
+};
 
 
 function pipeCtx (ctx, fns) {
@@ -155,7 +163,7 @@ function validatePath (path) {
 }
 
 function getMethods (resource) {
-  return methods.filter(m => resource[m])
+  return methods.filter(m => resource[m]);
 }
 
 function rethrow (ctx, err) { throw err; }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Resource-oriented routing for Koa 2+",
   "main": "lib/index.js",
   "scripts": {
-    "test": "nyc mocha",
+    "test": "eslint test lib; nyc mocha",
     "cover": "nyc report --reporter=text-lcov | coveralls",
     "travis": "npm run test; npm run cover;"
   },
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/nickb1080/koa-detour",
   "devDependencies": {
     "coveralls": "^2.6.1",
+    "eslint": "^3.14.1",
     "expect": "^1.20.2",
     "istanbul": "^0.2.3",
     "jshint": "2.4.0",
@@ -44,6 +45,7 @@
   },
   "dependencies": {
     "methods": "0.1.0",
+    "p-try": "^1.0.0",
     "path-to-regexp": "^1.6.0",
     "urlgrey": "0.4.4"
   }


### PR DESCRIPTION
This PR addresses #1

Add an `attempt` function which wraps up how to use `this._handleErr` and `this._handleOk` to deal with rejected/resolved promises, then use it with all exit paths of `_dispatch`.
